### PR TITLE
Add options for user to select test reporters

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -45,12 +45,27 @@ KataGenerator.prototype.askFor = function () {
       name: 'ChromeCanary',
       value: 'ChromeCanary'
     }]
+  },
+  {
+    type: 'checkbox',
+    name: 'reporters',
+    message: 'Which reporters do you want to use for the test output?',
+    choices: [{
+      name: 'Spec',
+      value: 'spec',
+      checked: true
+    }, {
+      name: 'Growl (Mac only)',
+      value: 'growl'
+    }],
+    default: ['spec']
   }];
 
   this.prompt(prompts, function (props) {
     this.nameOfKata = props.nameOfKata;
     this.nameOfAuthor = props.nameOfAuthor;
     this.browser = props.browser;
+    this.reporters = props.reporters;
     cb();
   }.bind(this));
 };

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -22,8 +22,8 @@
     "karma-jasmine": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
-    "karma": "~0.10.1",
-    "karma-growl-reporter": "~0.1.0",
+    "karma": "~0.10.1",<% if (reporters.indexOf('growl') !== -1) { %>
+    "karma-growl-reporter": "~0.1.0",<% } %>
     "karma-spec-reporter": "0.0.5"
   }
 }

--- a/app/templates/karma.conf.js
+++ b/app/templates/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
 
     // test results reporter to use
     // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['spec', 'growl'],
+    reporters: [<%= reporters.map(function (reporter) { return '\'' + reporter + '\'' }).join(', ') %>],
 
 
     // web server port

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-kata",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A generator for Yeoman",
   "keywords": [
     "yeoman-generator"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -27,7 +27,7 @@ describe('kata generator', function () {
     ];
 
     helpers.mockPrompt(this.app, {
-      'someOption': true
+      reporters: ['spec']
     });
 
     this.app.options['skip-install'] = true;


### PR DESCRIPTION
To avoid warnings on Windows (missing Growl), the user can now choose, which reporters to use for the test output (with 'spec' reporter being the default).
