### PR TITLE
Refresh dev dependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "jasmine-core": "*",
-    "phantomjs": "*",
+    "phantomjs-prebuilt": "*",
     "karma": "*",
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",
@@ -30,7 +30,8 @@
     "karma-coffee-preprocessor": "*",<% } else if (typescript) {%>
     "typescript": "*",
     "karma-typescript-preprocessor": "*",<%} else {%>
-    "babel-preset-es2015": "*",
+    "babel-core": "*",
+    "babel-preset-env": "*",
     "karma-babel-preprocessor": "*", <%}%>
     "karma-spec-reporter": "*"
   },


### PR DESCRIPTION
Some dependencies have become obsolete over time + new babel-core dependency is now required to run the kata.